### PR TITLE
Update argonaut-codecs version in Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
         "output"
     ],
     "dependencies": {
-        "purescript-argonaut-codecs": "^v6.0.2",
+        "purescript-argonaut-codecs": "^v7.0.0",
         "purescript-arrays": "^v5.3.1",
         "purescript-partial": "^v2.0.1",
         "purescript-prelude": "^v4.1.1",


### PR DESCRIPTION
Argonaut's type-class-based decoders now use typed errors instead of strings, so I'm making sure libraries which depend on it are compatible with the new version. Fortunately, while your library depends on Argonaut, it just derives instances and is compatible with either version. That means when the new package set comes out you're good to go with no library changes!

Still, I went ahead and updated your Bower file to accommodate the major version bump. You may want to make a release for anyone still using Bower to manage their dependencies and install this library.

Thanks!